### PR TITLE
Fix incorrect comment in CurrentValueRelayTests

### DIFF
--- a/Tests/AsyncCombineTests/Core/CurrentValueRelayTests.swift
+++ b/Tests/AsyncCombineTests/Core/CurrentValueRelayTests.swift
@@ -38,7 +38,7 @@ struct CurrentValueRelayTests {
         await relay.send(1)
         await relay.send(2)
 
-        // THEN we should receive 1, 2, and 3
+        // THEN we should receive 0, 1, and 2
         let values = await stream.collect(count: 3)
         #expect(values == [0, 1, 2])
     }


### PR DESCRIPTION
The `emitsSubssequntUpdates` test had a comment stating it should receive `1, 2, and 3`, but the actual sequence (including initial value) is `0, 1, and 2`. This PR corrects the comment to match the actual expected values.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.